### PR TITLE
New option to find images in the metadata catalogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,14 @@ The routine provided below enables to automatically download LANDSAT data, using
 
 It works for LANDSAT 8 and LANDSAT 5&7, but needs that the data be already online. It was true for LANDSAT 8 until September 2014, but after that date, to avoid increasing the on-line data volume indefinitly, USGS started to clean out older data to replace them by the new ones. It is also the case for the older LANDSAT satellites. Depending on the products you need, it may be necessary to first order for the production of L1T products, on the earthexplorer site http://earthexplorer.usgs.gov. And of course, you will need to have an account and password on the Earthexplorer website, and you will have to store it on the usgs.txt file. If you have an access through a proxy, you might try the -p option. it works through CNES proxy at least but was only tested there.
 
-This routine may be used in two ways :
+This routine may be used in three ways :
 
-- by providing the WRS-2 coordinates of the LANDSAT scene, for instance, (198,030) for Toulouse (-s option), , the start date (-d option), and the end date (-f option). If the end date is not provided, it is replaced by today's date by default. Example:
+- iterative search, by providing the WRS-2 coordinates of the LANDSAT scene, for instance, (198,030) for Toulouse (-s option), , the start date (-d option), and the end date (-f option). If the end date is not provided, it is replaced by today's date by default. Example:
 
 `       download_landsat_scene.py -o scene -b LC8 -d 20130127  -s 181025 -u usgs.txt -p proxy.txt --output /mnt/data/LANDSAT8/N0/`
+- catallogue search, by providing the WRS-2 coordinates of the LANDSAT scene, for instance, (198,030) for Toulouse (-s option), , the start date (-d option), and the end date (-f option). If the end date is not provided, it is replaced by today's date by default. Example:
+
+`       download_landsat_scene.py -o catallogue -b LC8 -d 20130127  -s 181025 -u usgs.txt -p proxy.txt --output /mnt/data/LANDSAT8/N0/`
 
 - by providing a list of products to download, as in the example below:
 
@@ -25,6 +28,8 @@ The usgs.txt must contain your username and password on the same line separated 
 
 If you do not use the --ouput option, the files will be downloaded to /tmp/Landsat (provided it exists)
 
+Set a cloud limit to get only images with cloud cover bellow that limit. In the catallogue search mode, the program will get the best image bellow that limit. For example, if you set a limit of 20% and it finds 3 images it will download the one will less cloud cover.
+
 To see all the options : 
 `       download_landsat_scene.py -h`
 
@@ -38,7 +43,7 @@ Here is what we found so far :
 
 | Satellite name | directory    | Stations                                       | Versions |
 
-| LT5            |  3119        | GLC,ASA,KIR,MOR,KHC,PAC,KIS,CHM,LGS,MGR,COA,MPS|   0-1    |
+| LT5            |  3119,4345   | GLC,ASA,KIR,MOR,KHC,PAC,KIS,CHM,LGS,MGR,COA,MPS|   0-1    |
 
 | LE7            |  3373,3372   |'EDC','SGS','AGS','ASN'                         |   0-1    |
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ This routine may be used in three ways :
 - iterative search, by providing the WRS-2 coordinates of the LANDSAT scene, for instance, (198,030) for Toulouse (-s option), , the start date (-d option), and the end date (-f option). If the end date is not provided, it is replaced by today's date by default. Example:
 
 `       download_landsat_scene.py -o scene -b LC8 -d 20130127  -s 181025 -u usgs.txt -p proxy.txt --output /mnt/data/LANDSAT8/N0/`
-- catallogue search, by providing the WRS-2 coordinates of the LANDSAT scene, for instance, (198,030) for Toulouse (-s option), , the start date (-d option), and the end date (-f option). If the end date is not provided, it is replaced by today's date by default. Example:
+- catalog search, by providing the WRS-2 coordinates of the LANDSAT scene, for instance, (198,030) for Toulouse (-s option), , the start date (-d option), and the end date (-f option). If the end date is not provided, it is replaced by today's date by default. Example:
 
-`       download_landsat_scene.py -o catallogue -b LC8 -d 20130127  -s 181025 -u usgs.txt -p proxy.txt --output /mnt/data/LANDSAT8/N0/`
+`       download_landsat_scene.py -o catalog -b LC8 -d 20130127  -s 181025 -u usgs.txt -p proxy.txt --output /mnt/data/LANDSAT8/N0/`
 
 - by providing a list of products to download, as in the example below:
 

--- a/download_landsat_scene.py
+++ b/download_landsat_scene.py
@@ -483,7 +483,7 @@ def main():
             repert=['4923']
             collection_file=os.path.join(os.path.dirname(os.path.realpath(__file__)),'LANDSAT_8.csv')
         if produit.startswith('LE7'):
-            repert=['3372']
+            repert=['3372','3373']
             collection_file=os.path.join(os.path.dirname(os.path.realpath(__file__)),'LANDSAT_ETM.csv')			
         if produit.startswith('LT5'):
             repert=['3119','4345']

--- a/download_landsat_scene.py
+++ b/download_landsat_scene.py
@@ -221,16 +221,13 @@ def find_in_collection_metadata(collection_file,bird,cc_limit,date_start,date_en
             year_acq =int(row['acquisitionDate'][0:4])
             month_acq=int(row['acquisitionDate'][5:7])
             day_acq  =int(row['acquisitionDate'][8:10])
-            # print year_acq,month_acq, day_acq	
             acqdate=datetime.datetime(year_acq,month_acq, day_acq)
-            # print str(acqdate), row['path']+'='+wr2path, row['row']+'='+wr2row, row['cloudCoverFull']
             if 	int(row['path'])==int(wr2path) and int(row['row'])==int(wr2row) and float(row['cloudCoverFull'])<=cc_limit and date_start<acqdate<date_end:
                 cloudcoverlist.append(row['cloudCoverFull'] + '--' + row['sceneID'])
                 cc_values.append(float(row['cloudCoverFull']))				
             else:
                 sceneID=''
     for i in cloudcoverlist:
-        print i
         if float(i.split('--')[0])==min(cc_values):
             sceneID = i.split('--')[1]
     return sceneID

--- a/download_landsat_scene.py
+++ b/download_landsat_scene.py
@@ -165,7 +165,7 @@ def next_overpass(date1,path,sat):
 
 #############################"Get metadata files
 def getmetadatafiles(destdir,option):
-    print 'Verifying catallogue metadata files...'
+    print 'Verifying catalog metadata files...'
     home = 'http://landsat.usgs.gov/metadata_service/bulk_metadata_files/'
     links=['LANDSAT_8.csv','LANDSAT_ETM.csv','LANDSAT_ETM_SLC_OFF.csv','LANDSAT_TM-1980-1989.csv','LANDSAT_TM-1990-1999.csv','LANDSAT_TM-2000-2009.csv','LANDSAT_TM-2010-2012.csv']
     for l in links:
@@ -227,7 +227,7 @@ def check_cloud_limit(imagepath,limit):
 #############################"Find image with desired specs in usgs entire collection metadata
 
 def find_in_collection_metadata(collection_file,cc_limit,date_start,date_end,wr2path,wr2row):
-    print "Searching for images in catallogue..."
+    print "Searching for images in catalog..."
     cloudcoverlist = []
     cc_values = []	
     with open(collection_file) as csvfile:
@@ -276,7 +276,7 @@ def main():
         usage = "usage: %prog [options] "
         parser = OptionParser(usage=usage)
         parser.add_option("-o", "--option", dest="option", action="store", type="choice", \
-			    help="scene or liste", choices=['scene','liste','catallogue'],default=None)
+			    help="scene or liste", choices=['scene','liste','catalog'],default=None)
         parser.add_option("-l", "--liste", dest="fic_liste", action="store", type="string", \
 			    help="list filename",default=None)
         parser.add_option("-s", "--scene", dest="scene", action="store", type="string", \
@@ -301,8 +301,8 @@ def main():
 			    help="Dir number where files  are stored at USGS",default=None)
         parser.add_option("--station", dest="station", action="store", type="string", \
 			    help="Station acronym (3 letters) of the receiving station where the file is downloaded",default=None)	
-        parser.add_option("-k", "--updatecatalloguefiles", dest="updatecatalloguefiles", action="store", type="choice", \
-			    help="Update catallogue metadata files", choices=['update','noupdate'],default='noupdate')			
+        parser.add_option("-k", "--updatecatalogfiles", dest="updatecatalogfiles", action="store", type="choice", \
+			    help="Update catalog metadata files", choices=['update','noupdate'],default='noupdate')			
 
 
 
@@ -447,8 +447,8 @@ def main():
 									downloaded_ids.append(nom_prod)								
         log(rep,downloaded_ids)
 
-##########Telechargement des produits par catallogue metadata search
-    if options.option=='catallogue':
+##########Telechargement des produits par catalog metadata search
+    if options.option=='catalog':
         produit=options.bird
         path=options.scene[0:3]
         row=options.scene[3:6]
@@ -477,7 +477,7 @@ def main():
         if not(os.path.exists(rep_scene)):
             os.makedirs(rep_scene)
 
-        getmetadatafiles(os.path.dirname(os.path.realpath(__file__)), options.updatecatalloguefiles)			
+        getmetadatafiles(os.path.dirname(os.path.realpath(__file__)), options.updatecatalogfiles)			
 			
         if produit.startswith('LC8'):
             repert=['4923']
@@ -498,7 +498,7 @@ def main():
         			
         nom_prod=find_in_collection_metadata(collection_file,options.clouds,date_start,date_end,path,row)
         if nom_prod=='':
-            print 'No image was found in the catallogue with the given specifications! Exiting...'					
+            print 'No image was found in the catalog with the given specifications! Exiting...'					
         tgzfile=os.path.join(rep_scene,nom_prod+'.tgz')
         lsdestdir=os.path.join(rep_scene,nom_prod)
 

--- a/download_landsat_scene.py
+++ b/download_landsat_scene.py
@@ -498,9 +498,10 @@ def main():
         			
         nom_prod=find_in_collection_metadata(collection_file,options.clouds,date_start,date_end,path,row)
         if nom_prod=='':
-            print 'No image was found in the catalog with the given specifications! Exiting...'					
-        tgzfile=os.path.join(rep_scene,nom_prod+'.tgz')
-        lsdestdir=os.path.join(rep_scene,nom_prod)
+            sys.exit('No image was found in the catalog with the given specifications! Exiting...')
+        else:				
+            tgzfile=os.path.join(rep_scene,nom_prod+'.tgz')
+            lsdestdir=os.path.join(rep_scene,nom_prod)
 
         if os.path.exists(lsdestdir):
             print '   product %s already downloaded and unzipped'%nom_prod


### PR DESCRIPTION
new functions: 
 - find_in_collection_metadata: to find the images with the required specifications in the metadata catalog
 - getmetadatafiles: to get the metadata catalog files if not currently found locally, or to update if option "update" is set by the user

new process:
'Telechargement des produits par catallogue metadata search'
similar to 'Telechargement des produits par scene' but based on the info retrieved by the catalog search.

With this new method additional conditions can be set to select the images, namely if the image is "Processing Required" or already available.
