### PR TITLE
Bug when downloading with "-o liste"

### DIFF
--- a/download_landsat_scene.py
+++ b/download_landsat_scene.py
@@ -575,7 +575,7 @@ def main():
                 stations=['GLC','ASA','KIR','MOR','KHC', 'PAC', 'KIS', 'CHM', 'LGS', 'MGR', 'COA', 'MPS']	
             if not os.path.exists(rep+'/'+site):
                 os.mkdir(rep+'/'+site)
-            url="http:///earthexplorer.usgs.gov/download/%s/%s/STANDARD/EE"%(repert,produit)
+            url="http://earthexplorer.usgs.gov/download/%s/%s/STANDARD/EE"%(repert,produit)
             print 'url=',url
             try:
                 if options.proxy!=None :


### PR DESCRIPTION
The `-o liste` gives a runtime error because of an extra `/` in the url